### PR TITLE
fix: nested components and project naming context

### DIFF
--- a/repocfg/util.go
+++ b/repocfg/util.go
@@ -9,8 +9,15 @@ import (
 func ptr[T any](v T) *T { return &v }
 
 // friendlyName creates a contextual name used for Atlantis projects
-func friendlyName(path, environment string) string {
-	name := []string{strings.ReplaceAll(path, "/", "-"), pathWithoutExtension(filepath.Base(environment))}
+func friendlyName(path, varFile string) string {
+	environment := pathWithoutExtension(filepath.Base(varFile))
+
+	// avoid constructing a joined path if the context is the current directory
+	if filepath.Base(path) == "." {
+		return environment
+	}
+
+	name := []string{strings.ReplaceAll(path, "/", "-"), environment}
 	return strings.TrimSuffix(strings.Join(name, "-"), "-")
 }
 


### PR DESCRIPTION
## what
- fixes nested components being ignored from the resulting configuration via the `generate` command, e.g.
```
|── test
│   ├── dev.tfvars
│   ├── main.tf
│   ├── nested
│   │   ├── main.tf
│   │   ├── dev.tfvars
│   │   └── prod.tfvars
│   ├── prod.tfvars
```

- fixes issue where if running context is the same dir as component, project name produces undesirable naming e.g.
```yaml
version: 3
automerge: false
parallel_plan: false
parallel_apply: false
projects:
- name: .-dev
  dir: .
  workspace: dev
```