### PR TITLE
fix(generate): duplicates in atlantis.yaml

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-VERSION=v0.0.2
+VERSION=v0.0.4


### PR DESCRIPTION
## what
- fixes edge case where duplicates can end up in rendered `atlantis.yaml`

## why
Atlantis will respond with an error if there are duplicates in `atlantis.yaml`

>_parsing atlantis.yaml: found two or more projects with name "service-my-terraform-dev"; project names must be unique_

closes #3 